### PR TITLE
Fixed issue with math mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ A short rundown of **quantikz** usage is given below. I assume this is the forma
 % or you can completely copy-paste the output of pyquirk:
 
 \begin{quantikz}
-\lstick{\ket{0}}&\gate{H} & \ctrl{1} & \meter{}& \cw \\
-\lstick{\ket{0}}&\qw & \targ{} & \qw& \qw
+\lstick{$\ket{0}$}&\gate{H} & \ctrl{1} & \meter{}& \cw \\
+\lstick{$\ket{0}$}&\qw & \targ{} & \qw& \qw
 \end{quantikz}
 
 \end{center}

--- a/circuit.tex
+++ b/circuit.tex
@@ -1,5 +1,5 @@
 \begin{quantikz}
-\lstick{\ket{0}}&\gate{H} & \ctrl{1} & \swap{2}& \ghost{X} \qw \\
-\lstick{\ket{0}}&\qw & \targ{} & \qw& \ghost{X} \qw \\
-\lstick{\ket{0}}&\qw & \qw & \targX{}& \ghost{X} \qw
+\lstick{$\ket{0}$}&\gate{H} & \ctrl{1} & \swap{2}& \ghost{X} \qw \\
+\lstick{$\ket{0}$}&\qw & \targ{} & \qw& \ghost{X} \qw \\
+\lstick{$\ket{0}$}&\qw & \qw & \targX{}& \ghost{X} \qw
 \end{quantikz}

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,5 @@
 \documentclass{article}
+\usepackage{physics}
 \usepackage{tikz}
 \usetikzlibrary{quantikz}
 

--- a/pyquirk.py
+++ b/pyquirk.py
@@ -119,7 +119,7 @@ def vqw_append(subcol):
 def tex_initial_states(data):
     """Initial states are texed."""
     initial_state = []
-    initial_state = [''.join(["\lstick{\ket{", str(data['init'][row]),"}}"]) for row in range(len(data['init']))]
+    initial_state = [''.join(["\lstick{$\ket{", str(data['init'][row]),"}$}"]) for row in range(len(data['init']))]
     return data, initial_state
 
 def substitute_gates(data, vqw_ind, subcol, initial_state):


### PR DESCRIPTION
Fixed issue where `\lstick{\ket{0}}` would not work if the physics package is included.

Substituted all instances of `\ket{}` with `$\ket{}$` and included `physics` package.